### PR TITLE
add an option to stop GUI

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,11 +5,11 @@ go 1.19
 require (
 	github.com/JoelOtter/termloop v0.0.0-20210806173944-5f7c38744afb
 	github.com/google/uuid v1.3.0
+	github.com/nsf/termbox-go v1.1.1
 
 )
 
 require (
 	github.com/mattn/go-runewidth v0.0.14 // indirect
-	github.com/nsf/termbox-go v1.1.1 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect
 )


### PR DESCRIPTION
Termloop nie daje żadnej opcji na zatrzymanie gry, zaś implementacja jego gameloopa powoduje, że nie da się tego obejść. Jedyny sposób, jaki jestem w stanie wymyślić, to zasymulowanie kliknięcia przez użytkownika i dokładnie to robi ten PR.

Testowane na macOS 13.3.1 (arm64) oraz Ubuntu 23.04 (arm64). Jutro przetestuję te same systemy na amd64.